### PR TITLE
readme: specify module path in git mod init

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Option B: Using Go build commands with Go modules (works on any platform with Ba
 1. Run the following in the `x509-compressed` directory to set up Go modules:
    
    ~~~
-   go mod init
+   go mod init github.com/namecoin/x509-compressed
    go mod tidy
    go generate ./...
    go mod tidy


### PR DESCRIPTION
Fixes error:

	go: cannot determine module path for source directory
	/home/redfish/foo/ncdns (outside GOPATH, module path must be
	specified)
	
See also: https://github.com/namecoin/ncdns/pull/142