### PR TITLE
Avoid importing `internal/godebug`

### DIFF
--- a/x509/install.sh
+++ b/x509/install.sh
@@ -11,6 +11,10 @@ sed -i "s/elliptic.Marshal(/elliptic.MarshalCompressed(/g" ./*.go
 # These files use an internal package, we provide a skeleton to make it compile
 rm -f ./root_darwin_amd64.go ./root_darwin.go
 
+# Avoid importing internal/godebug
+sed -i 's|"internal/godebug"||g' ./*.go
+sed -i 's/godebug.Get("x509sha1")/"0"/g' ./*.go
+
 # Delete tests if they're present.  (On some distros, e.g. Fedora, they're
 # already removed.)
 for f in ./*_test.go


### PR DESCRIPTION
Fixes compatibility with Go 1.18.x.