### PR TITLE
godebug stub to fix build error with Go 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ x509-compressed is a fork of the Go standard `crypto/x509` library that uses com
 
 ## Building
 
-Prerequisites:
+### Prerequisites
 
-1. Ensure you have the Go tools installed.
+Ensure you have the Go tools installed.
 
-Option A: Using Go build commands without Go modules (works on any platform with Bash; only Go 1.15-1.16.x; will not work on Go 1.17+):
+### Option A: Using Go build commands without Go modules
+
+Should work on any platform with Bash; only Go 1.15-1.16.x; will not work on Go 1.17+:
 
 1. Ensure you have the GOPATH environment variable set. (For those not
    familar with Go, setting it to the path to an empty directory will suffice.
@@ -21,29 +23,39 @@ Option A: Using Go build commands without Go modules (works on any platform with
 
 4. You can now `import "github.com/namecoin/x509-compressed/x509"` from your Go projects.
 
-Option B: Using Go build commands with Go modules (works on any platform with Bash; Go 1.15+:
+### Option B: Using Go build commands with Go modules
 
-1. Run the following in the `x509-compressed` directory to set up Go modules:
+Should work on any platform with Bash; Go 1.15+:
+
+1. Run the following in the `x509-compressed/godebug` directory to initialize the stub substitute for the `internal/godebug`  module:
+
+   ~~~
+   go mod init github.com/namecoin/x509-compressed/godebug
+   go mod tidy
+   cd ..
+
+2. Run the following in the `x509-compressed` directory to set up Go modules:
    
    ~~~
    go mod init github.com/namecoin/x509-compressed
+   go mod edit -replace github.com/namecoin/x509-compressed/godebug=./godebug
    go mod tidy
    go generate ./...
    go mod tidy
    ~~~
 
-2. Place your application's directory as a sibling of the `x509-compressed` directory.
+3. Place your application's directory as a sibling of the `x509-compressed` directory.
 
-3. Run the following in your application's directory:
+4. Run the following in your application's directory:
    
    ~~~
-   go mod edit -replace github.com/namecoin/x509-compressed=../x509-compressed
+   go mod edit -replace github.com/namecoin/x509-compressed=../x509-compressed -replace github.com/namecoin/x509-compressed/godebug=../x509-compressed/godebug
    go mod tidy
    ~~~
 
-4. You can now `import "github.com/namecoin/x509-compressed/x509"` from your Go application.
+5. You can now `import "github.com/namecoin/x509-compressed/x509"` from your Go application.
 
-## Licence
+## License
 
 Original Go standard library code Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/godebug/godebug.go
+++ b/godebug/godebug.go
@@ -1,0 +1,32 @@
+// A stub for internal/godebug module from standard library.
+// Since 'internal' modules are not importable, we have this substitute.
+
+package godebug
+
+type Setting struct {
+	name string
+}
+
+func New(name string) *Setting {
+	return &Setting{name: name}
+}
+
+func (s *Setting) Name() string {
+	return s.name
+}
+
+func (s *Setting) Value() string {
+	// all GODEBUG options are false by default unless overriden, so return false
+	return "0"
+}
+
+func (s *Setting) String() string {
+	return s.Name() + "=" + s.Value()
+}
+
+func (s *Setting) Undocumented() bool {
+	return false
+}
+
+func (s *Setting) IncNonDefault() {
+}

--- a/x509/install.sh
+++ b/x509/install.sh
@@ -11,9 +11,9 @@ sed -i "s/elliptic.Marshal(/elliptic.MarshalCompressed(/g" ./*.go
 # These files use an internal package, we provide a skeleton to make it compile
 rm -f ./root_darwin_amd64.go ./root_darwin.go
 
-# Avoid importing internal/godebug
-sed -i 's|"internal/godebug"||g' ./*.go
-sed -i 's/godebug.Get("x509sha1")/"0"/g' ./*.go
+# Replace un-importable internal/godebug with a stub
+find . -name "*.go" -type f -exec \
+  sed -i 's|"internal/godebug"|"github.com/namecoin/x509-compressed/godebug"|g' {} \;
 
 # Delete tests if they're present.  (On some distros, e.g. Fedora, they're
 # already removed.)


### PR DESCRIPTION
Upstream interface to internal/godebug has [changed](https://go.googlesource.com/go/+/refs/heads/master/src/internal/godebug/godebug.go), so the sed replace from [PR#3](https://github.com/namecoin/x509-compressed/pull/3) is no longer matching nor is suffcient in Go 1.21. Build fails with errors on lines with godebug references.

	c0d381ed1b75be15a45a8d3629c01945e309ece9
	Avoid importing internal/godebug

Suggesting a different approach: substitute godebug with a stub. Hopefully it's more robust than hacking more sed replace expression to cover every line.  Still might go out of date if upstream changes the interface again, but updating the stub to match the updated interface should be more straightforward than with sed expressions.

Since godebug is accessed via `godebug.Foo()`, godebug stub needs to be an actual module with its own path. Imports via a relative paths are not allowed in "module mode". True? Or is there a trick to somehow make this godebug stub a "local" module?

The downside of the stub being a module is that now one extra module path needs to be replaced with 'go mod edit' to point to the local directory. And, unfortunately, it is not sufficient to do it only in the dependency module; it needs also needs to be done for the parent application.

Also, for build on Go <1.17 without Go modules, I didn't try it, but presumably no separate command is needed, assuming go get is smart enough to find the nested godebug stub, just like it finds the other local dependencies modules. Not sure.